### PR TITLE
FIX : SQL injection error

### DIFF
--- a/script/splitLines.php
+++ b/script/splitLines.php
@@ -143,7 +143,8 @@
 	    }       
 	}
 
-	if ($action !== 'delete' && method_exists($new_object, 'getNomUrl'))
+	if ($action !== 'delete')
     {
-        print urlencode($new_object->getNomUrl());
+        if(floatval(DOL_VERSION) <= 12.0 && method_exists($new_object, 'getNomUrl')) print urlencode($new_object->getNomUrl());
+        elseif(floatval(DOL_VERSION) > 12.0) print urlencode($new_object->ref);
     }


### PR DESCRIPTION
A partir de la version 13.0 de Dolibarr, les actions du module Split sont considérées comme étant des injections SQL à cause des doubles quotes passées dans les paramètres GET à cause du getNomUrl